### PR TITLE
Add README with macOS 26 compatibility note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# puppet-gatekeeper
+
+A Puppet module that ensures Gatekeeper is enabled on macOS.
+
+## macOS Version Compatibility
+
+Tested and compatible with macOS 26 (Tahoe).


### PR DESCRIPTION
Adds a README documenting the module and noting it is tested and compatible with macOS 26 (Tahoe).